### PR TITLE
Compatibility with Node v6.x.

### DIFF
--- a/lib/phpfunctions.js
+++ b/lib/phpfunctions.js
@@ -11,7 +11,7 @@ function strpos(string, find){
 
 function md5(string, raw){
     var hash = crypto.createHash('md5');
-    hash.update(string);
+    hash.update(string, 'binary');
     if(raw)
         return hash.digest('binary');
     else


### PR DESCRIPTION
In Node.js v6.x, hash.update assumes the input to be utf8. Previous versions of Node.js assumes the input to be in binary. This causes hashes generated to be incompatible between Node.js < 6.x and >= 6.x. Make the call to hash.update explicit so that hashes can continue to be compatible.
